### PR TITLE
build: update makefile to allow assignment configurations, including zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,25 @@
 
+# By default, we are not compiling on marmoset. This is overwritten by
+# `assignment.mk`
+MARMOSET := false
+
+# When compiling, if an assignment target (`ASSN`) is not provided, such
+# as in marmoset, then `assignment.mk` will be included. This
+# includes `ASSN := Ax`. This allows assignment specific marmoset
+# zip creation.
+ifndef ASSN
+
+# If assignment.mk does not exist, this is being run locally
+# without `ASSN` incorrectly.
+ifeq ("","$(wildcard ./assignment.mk)")
+$(error "Please provide an assignment target. For example: `make joosc ASSN=A2`")
+endif
+
+include assignment.mk
+endif
+
+# TODO(joey): Check that `ASSN` is valid.
+
 CRYSTAL_SRCS := $(shell find ./src -name '*.cr')
 JLALR_SRCS := $(shell find tools/jlalr -name '*.java')
 
@@ -9,7 +30,7 @@ all: joosc orangejoos docs
 
 joosc: ## joosc is the general compiler.
 joosc: $(CRYSTAL_SRCS) grammar/joos1w.lr1
-	crystal build ./src/joosc.cr
+	crystal build ./src/joosc.cr -D$(ASSN)
 
 orangejoos: ## orangejoos is the general compiler with debug options.
 orangejoos: $(CRYSTAL_SRCS) grammar/joos1w.lr1
@@ -23,14 +44,20 @@ tools/jlalr/Jlalr1.class: ## JLALR1 is the LALR(1) prediction table generated, p
 tools/jlalr/Jlalr1.class: $(JLALR_SRCS)
 	javac ./tools/jlalr/Jlalr1.java
 
-.PHONY: clean
-clean:
-	find . -name '*.class' | xargs -I{} rm {}
-	rm -f joosc.jar
+.PHONY: clean-light
+clean-light: ## Removes standard binary results.
+clean-light:
 	rm -f orangejoos orangejoos.dwarf
 	rm -f orangejoos.zip
 	rm -f joosc joosc.dwarf
 	rm -f failed_tests.tmp
+	rm -f assignment.mk
+
+.PHONY: clean
+clean: ## Removes all built results.
+clean: clean-light
+	find . -name '*.class' | xargs -I{} rm {}
+	rm -f joosc.jar
 	rm -f grammar/joos1w.lr1
 	rm -f grammar/joos1w.cfg
 
@@ -44,8 +71,11 @@ grammar/joos1w.lr1: grammar/joos1w.cfg tools/jlalr/Jlalr1.class
 
 .PHONY: orangejoos.zip
 orangejoos.zip: ## Zip up the compiler for submission on marmoset.
-orangejoos.zip: clean
+orangejoos.zip: clean-light grammar/joos1w.lr1
+	echo "export ASSN := $(ASSN)\nexportMARMOSET := true" > assignment.mk
 	zip -r $@ . -x orangejoos.zip .git/\* .idea/\* docs/\* joosc orangejoos orangejoos.dwarf joosc.dwarf pub/\* test/\*
+	rm -rf assignment.mk
+
 
 docs:
 	crystal docs

--- a/src/argparser.cr
+++ b/src/argparser.cr
@@ -1,5 +1,13 @@
 require "option_parser"
 
+{% if flag?(:A2) %}
+END_STAGE = Stage::ALL
+{% elsif flag?(:A1) %}
+END_STAGE = Stage::WEED
+{% else %}
+"Compilation error: unexpected assignment"
+{% end %}
+
 # haha nice meme dude
 module Bruce
   BANNER = "Usage: joosc compile [arguments] [files...]\n" \
@@ -8,10 +16,10 @@ end
 
 # ArgParser parses options for the joosc compiler.
 class ArgParser
-  getter verbose    = false
-  getter end_stage  = "all"   # default runs the entire pipeline
-  getter paths      = [] of String
-  getter table_file = "grammar/joos1w.lr1"
+  getter verbose    : Bool   = false
+  getter end_stage  : Stage  = END_STAGE
+  getter paths               = [] of String
+  getter table_file : String = "grammar/joos1w.lr1"
 
   def initialize(args : Array(String))
     OptionParser.parse(args) do |parser|
@@ -23,7 +31,7 @@ class ArgParser
         @table_file = path
       end
       parser.on("-s STAGE", "--stage=STAGE", "compiler stage to stop execution at" ) do |stage|
-        @end_stage = stage
+        @end_stage = Stage.get(stage)
       end
       parser.unknown_args { |args| @paths = args }
     end

--- a/src/orangejoos/pipeline.cr
+++ b/src/orangejoos/pipeline.cr
@@ -20,8 +20,7 @@ class Pipeline
     validate # make sure args are correct
   end
 
-  def initialize(@table_file : String, @paths : Array(String), end_stage : String, @verbose : Bool)
-    @end_stage = Stage.get(end_stage.downcase)
+  def initialize(@table_file : String, @paths : Array(String), @end_stage : Stage, @verbose : Bool)
     validate # make sure args are correct
   end
 

--- a/src/orangejoos/stage.cr
+++ b/src/orangejoos/stage.cr
@@ -9,7 +9,7 @@ enum Stage
 
   # takes a string and gets the corresponding enum token, or else raises an exception
   def self.get(stage : String) Stage
-    case stage
+    case stage.downcase
     when "scan"     then return Stage::SCAN
     when "parse"    then return Stage::PARSE
     when "simplify" then return Stage::SIMPLIFY


### PR DESCRIPTION
The tl;dr is the makefile now requires `ASSN=Ax` parameter during
compilation to compile in a default configuration, which is just the
default end stage for now. This is just passing forward the make
parameter as a compiler flag.

It also handles `orangejoos.zip` as it will write the parameter to a
file that is then imported on marmoset for the configuration. This lets
you do `make orangejoos.zip ASSN=A1` to generate an A1 zip.