### PR TITLE
Fix build and tester

### DIFF
--- a/src/argparser.cr
+++ b/src/argparser.cr
@@ -4,8 +4,10 @@ require "option_parser"
 END_STAGE = Stage::ALL
 {% elsif flag?(:A1) %}
 END_STAGE = Stage::WEED
+{% elsif flag?(:A_NONE) %}
+END_STAGE = Stage::WEED
 {% else %}
-"Compilation error: unexpected assignment"
+Compilation error: unexpected assignment
 {% end %}
 
 # haha nice meme dude

--- a/tester.sh
+++ b/tester.sh
@@ -2,7 +2,7 @@
 
 file_name_test=$1
 
-if make ; then
+if make ASSN=A_NONE ; then
   :
 else
   exit 1


### PR DESCRIPTION
After modifying the make system, the tester was not working. This fixes
that. The tester builds with no assignment target but is expected to
define the end stage. In the future, the tester script could have a
switch of assignments and the test folders so the proper make target is
used.

cc: @keriwarr merging but PRing for visibility.