### PR TITLE
typing: Add stubbed type interface

### DIFF
--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -8,7 +8,8 @@
 # node.
 
 
-require "./visitor.cr"
+require "./visitor"
+require "./typing"
 
 INDENT = ->(depth : Int32) { "  " * depth }
 
@@ -77,7 +78,15 @@ module AST
   # of `Stmt`, meaning they are also traversable and are only
   # distinguished by the property of returning values.
   abstract class Expr < Stmt
+    include Typing
+
     def initialize
+    end
+
+    # TODO(joey): Implement for each type and remove this stubbed method.
+    private def resolve_type
+      raise Exception.new("Unimplemented")
+      return ExprTyp.new("huzza")
     end
   end
 
@@ -709,7 +718,7 @@ module AST
   class ExprArrayCreation < Expr
     # FIXME(joey): Specialize the node type used here. Maybe if we
     # create a Type interface that multiple AST nodes can implement,
-    # such as Name (or Class/Interface) and PrimativTyp.
+    # such as Name (or Class/Interface) and PrimitiveTyp.
     property arr : Node
     property dim : Expr
 

--- a/src/orangejoos/typing.cr
+++ b/src/orangejoos/typing.cr
@@ -1,0 +1,24 @@
+class ExprTyp
+  property name : String
+
+  def initialize(@name : String)
+  end
+
+  def ==(other : ExprTyp)
+    return self.name == other.name
+  end
+end
+
+module Typing
+  property! expr_typ : ExprTyp
+
+  def get_type : ExprTyp
+    if self.expr_typ?
+      return self.expr_typ
+    end
+    self.expr_typ = self.resolve_type
+    return self.expr_typ
+  end
+
+  private abstract def resolve_type() : ExprTyp
+end


### PR DESCRIPTION
This is something I had in mind for doing typing on the expressions. There is an interface that is included in `Expr`, that each type will implement. Similar to visitors, they will have to recursively call on each sub-children that is specific to each expr.

I think at the higher level (Stmts or other nodes), types are only checked in very few specific cases.

This was just putting on paper the interface I was thinking of and pairing it with the idiomatic Ruby-ism interfaces. The `ExprTyp` should probably also be a `Typ`. Also, I don't know if `Typ` should be an `Expr`. (The reasoning is somewhere in the parse tree bits 😅just haven't checked yet).