### PR TITLE
nameres: resolve all `ReferenceTyp` to a Class/Interface

### DIFF
--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -159,6 +159,7 @@ module AST
   # including the cardinality.
   class ReferenceTyp < Typ
     property name : Name
+    property cardinality : Int32
 
     def initialize(@name : Name)
       @cardinality = 0

--- a/src/orangejoos/name_resolution.cr
+++ b/src/orangejoos/name_resolution.cr
@@ -183,6 +183,8 @@ class NameResolution
     files = files.map {|file| check_correctness(file)}
 
 
+
+
     return @files
   end
 end
@@ -491,6 +493,24 @@ class DuplicateFieldVisitor < Visitor::GenericVisitor
       field_set.add(field.decl.name)
     end
 
+    return super
+  end
+end
+
+# `ReferenceTypResolutionVisitor` resolves the types in variable and
+# field declarations.
+class ReferenceTypResolutionVisitor < Visitor::GenericVisitor
+  @namespace : ImportNamespace
+
+  def initialize(@namespace : ImportNamespace)
+  end
+
+  def visit(node : AST::ReferenceTyp) : AST::Node
+    typ = @namespace.fetch(node.name)
+    if typ.nil?
+      raise NameResolutionStageError.new("#{node.name.name} type was not found")
+    end
+    node.name.ref = typ
     return super
   end
 end


### PR DESCRIPTION
Results: A2 `152 / 228` (no change). A3 `192 / 323` (no change)

ReferenceTyp are used in a few places:
1) the type in a field declaration
2) the type in a variable declaration
3) the type in a class init or array init
4) the type in method signatures (arguments and return)

This change populates the `ReferenceTyp.ref` to refer to the
Class/Interface at that location.

What still needs to be done is:
- Resolve all reference types in cast expressions. e.g. `(java.io.Buffer) A`. Currently, the AST has a Name so it does not get fulfilled. The AST should be modified to instead use a `ReferenceTyp`.
- Resolve all reference types in `instanceof` operators. e.g. `<expr> instanceof java.io.Buffer`. Currently, the `instanceof` is a regular expression so this is not possible. The `instanceof` operator will have to be specialized so the RHS is a `ReferenceTyp` that is attempted to be resolved.

Both of those are flaws in the AST, but I'm going to skip over them for now because there will (hopefully) only be a few test cases with these two situations.