### PR TITLE
fix CastExpr AST generation

### DIFF
--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -133,7 +133,7 @@ module AST
   # `PrimitiveTyp` also contains the _cardinality_ of the represented
   # type.
   class PrimitiveTyp < Typ
-    @name : String
+    getter name : String
 
     def initialize(@name : String)
       @cardinality = 0
@@ -1062,44 +1062,21 @@ module AST
 
   class CastExpr < Expr
     property rhs : Expr
-    property! typ : PrimitiveTyp
-    property is_arr : Bool
-    property! expr : Expr
-    property! name : Name
+    property typ : Typ
 
-    def initialize(@rhs : Expr, @typ : PrimitiveTyp, @is_arr : Bool)
-    end
-
-    def initialize(@rhs : Expr, @expr : Expr)
-      @is_arr = false
-    end
-
-    def initialize(@rhs : Expr, @name : Name)
-      @is_arr = true
+    def initialize(@rhs : Expr, @typ : Typ)
     end
 
     def pprint(depth : Int32)
       indent = INDENT.call(depth)
-      type_str = (
-        if typ?
-          typ.pprint(0)
-        elsif expr?
-          expr.pprint(0)
-        else
-          name.pprint(0)
-        end
-      )
-
-      return "#{indent}Cast: type={#{type_str}} value={#{@rhs.pprint(0)}}"
+      return "#{indent}Cast: type={#{typ.pprint}} value={#{@rhs.pprint(0)}}"
     end
 
     def children
-      if expr?
-        [rhs, expr] of Expr
-      else
-        [rhs] of Expr
-      end
+      [rhs] of Expr
     end
+
+    # TODO(joey): Add get_type() for new CastExpr.
   end
 
   class ParenExpr < Expr

--- a/src/orangejoos/name_resolution.cr
+++ b/src/orangejoos/name_resolution.cr
@@ -151,11 +151,13 @@ class NameResolution
     file.ast.accept(CycleVisitor.new(namespace, cycle_tracker))
     file.ast.accept(ReferenceTypResolutionVisitor.new(namespace))
 
+    file.ast.accept(ReferenceTypResolutionVisitor.new(namespace))
+
     return file
   end
 
   def check_correctness(file)
-      file.ast.accept(DuplicateFieldVisitor.new)
+    file.ast.accept(DuplicateFieldVisitor.new)
   end
 
 

--- a/src/orangejoos/visitor.cr
+++ b/src/orangejoos/visitor.cr
@@ -219,6 +219,7 @@ module Visitor
 
     def visit(node : AST::CastExpr) : Nil
       node.rhs.accept(self)
+      node.typ.accept(self)
     end
 
     def visit(node : AST::ParenExpr) : Nil

--- a/src/orangejoos/weeding.cr
+++ b/src/orangejoos/weeding.cr
@@ -16,7 +16,6 @@ class Weeding
     @root.accept(PublicDeclVisitor.new)
     @root.accept(CheckPublicDeclNameVisitor.new(@public_class_name))
     @root.accept(LiteralRangeCheckerVisitor.new)
-    @root.accept(InvalidCastExpressionVisitor.new)
   end
 end
 
@@ -143,16 +142,6 @@ class LiteralRangeCheckerVisitor < Visitor::GenericVisitor
       node.val.to_i32
     rescue ArgumentError
       raise WeedingStageError.new("Integer out of bounds")
-    end
-  end
-end
-
-class InvalidCastExpressionVisitor < Visitor::GenericVisitor
-  def visit(node : AST::CastExpr) : Nil
-    return node unless node.expr?
-
-    unless node.expr.is_a?(AST::Typ) || node.expr.is_a?(AST::ExprRef)
-      raise WeedingStageError.new("Cannot cast value #{node.rhs.pprint(0)} to #{node.expr.pprint(0)}")
     end
   end
 end


### PR DESCRIPTION
This changes the `CastExpr`. Previously to represent the cast type it
contained a `Name`, `Expr`, or `PrimitiveTyp`. This was simplified to
only a `Typ`.

This was done in order to fix problems that prevented resolving the
`ReferenceTyp` names during name resolution. It also vastly simplifies
how casts are handled.

The visitor checking the cast validity was also removed, and the check
is now done during simplification. It will ensure the child expression
tree of the CastExpr is a Name, and if not an error will be thrown. The
name is also ensured to be valid during name resolution.

----

*A2: no change*
*A3 no change*