### PR TITLE
add Class fields to the variable namespace during resolution

### DIFF
--- a/src/joosc.cr
+++ b/src/joosc.cr
@@ -21,9 +21,9 @@ rescue ex : NameResolutionStageError
   STDERR.puts "#{ex.inspect_with_backtrace}"
   exit 42
 rescue ex : CompilerError
-  STDERR.puts ex
+  STDERR.puts ex.inspect_with_backtrace
   exit 42
 rescue ex : Exception
-  STDERR.puts ex
+  STDERR.puts ex.inspect_with_backtrace
   exit 42 # TODO(slnt) exit differently if verbose specifed?
 end

--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -319,6 +319,9 @@ module AST
 
     def fields : Array(FieldDecl)
       visible_fields = body.select(&.is_a?(FieldDecl))
+      # TODO(joey): Filter out fields that will be shadowed. Currently,
+      # there will be duplicates. The order of fields matter so that
+      # shadowing fields will be near the front.
       visible_fields += super_class.ref.as(ClassDecl).fields if super_class?
       return visible_fields.map(&.as(FieldDecl))
     end
@@ -445,15 +448,15 @@ module AST
   # ```
   class FieldDecl < MemberDecl
     property typ : Typ
-    property decl : VariableDecl
+    property var : VariableDecl
 
-    def initialize(modifiers : Array(Modifier), @typ : Typ, @decl : VariableDecl)
+    def initialize(modifiers : Array(Modifier), @typ : Typ, @var : VariableDecl)
       self.modifiers = modifiers
     end
 
     def pprint(depth : Int32)
       indent = INDENT.call(depth)
-      return "#{indent}field #{decl.pprint(0)} type=#{typ.name_str} mods=#{modifiers.join(",")}"
+      return "#{indent}field #{var.pprint(0)} type=#{typ.name_str} mods=#{modifiers.join(",")}"
     end
   end
 
@@ -496,6 +499,8 @@ module AST
 
   # `Param` represents a parameter definition in a method signature. It
   # includes the _name_ and _typ_ of the paramter.
+  # TODO(joey): If the Param wraps a `VariableDecl` or we remove `Param`
+  # outright, this will simplify variable resolution code.
   class Param < Node
     property name : String
     property typ : Typ

--- a/src/orangejoos/mutating_visitor.cr
+++ b/src/orangejoos/mutating_visitor.cr
@@ -103,7 +103,7 @@ module Visitor
 
     def visit(node : AST::FieldDecl) : AST::Node
       node.typ = node.typ.accept(self)
-      node.decl = node.decl.accept(self)
+      node.var = node.var.accept(self)
       return node
     end
 

--- a/src/orangejoos/visitor.cr
+++ b/src/orangejoos/visitor.cr
@@ -107,7 +107,7 @@ module Visitor
 
     def visit(node : AST::FieldDecl) : Nil
       node.typ.accept(self)
-      node.decl.accept(self)
+      node.var.accept(self)
     end
 
     def visit(node : AST::File) : Nil

--- a/src/orangejoos/weeding.cr
+++ b/src/orangejoos/weeding.cr
@@ -70,7 +70,7 @@ class ClassDeclVisitor < Visitor::GenericVisitor
   def handleFieldDecl(node : AST::ClassDecl, fd : AST::FieldDecl)
     # Do not allow fields to be final.
     if fd.has_mod?("final")
-      raise WeedingStageError.new("field #{node.name}.#{fd.decl.name} is final, but final is not allowed")
+      raise WeedingStageError.new("field #{node.name}.#{fd.var.name} is final, but final is not allowed")
     end
   end
 


### PR DESCRIPTION
*A2: no change*

---

Previously, fields (both static and non-static) were not accounted for
during name resolution. Now, they both are populated into the namespace
prior to traversing through the method and the variables being resolved.

All of these fields are used the same way as variables, i.e. without a
preceding `this`. Only implicit `this` field access is allowed in
Joos1W.

When traversing through a static method, only static variables are
populated. Likewise, only non-static fields are populated for non-static
methods.