### PR TITLE
Fix MethodEnvironmentVisitor must visit interfaces

### DIFF
--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -344,6 +344,8 @@ module AST
     property! qualified_name : String
 
     abstract def methods : Array(MethodDecl)
+    abstract def non_static_fields : Array(FieldDecl)
+    abstract def static_fields : Array(FieldDecl)
 
     def method?(name : String, args : Array(Typing::Type)) : MethodDecl?
       signature = MethodSignature.new(name, args)
@@ -453,6 +455,14 @@ module AST
         return true if interface.extends?(node)
       end
       return false
+    end
+
+    def non_static_fields : Array(FieldDecl)
+      [] of FieldDecl
+    end
+
+    def static_fields : Array(FieldDecl)
+      [] of FieldDecl
     end
 
     def ast_children : Array(Node)


### PR DESCRIPTION
A2 progress: 164->173

Previously, there was an issue where seemingly any time we visit a
MethodDecl that is the child of an Interface, before a ClassDecl has
been visited, an error would be thrown.
This was because the MethodDecl visitor assumed that a class has
been visited already.

The code has been modifide to visit all TypeDecls instead. This was done
because we still want to visit the MethodDecls inside of Interfaces to
check their names and the names of their parameters.