### PR TITLE
typing: handle != just like ==

### DIFF
--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -800,7 +800,7 @@ module AST
         end
       end
 
-      if op == "==" && operands.size == 2
+      if ["==", "!="].includes?(op) && operands.size == 2
         lhs = operands[0].get_type(namespace)
         rhs = operands[1].get_type(namespace)
         if Typing.can_convert_type(rhs, lhs)


### PR DESCRIPTION
Previously, a special case was applied for "==" which allowed any
convertable types, via `Typing.can_convert_type`, to be allowed. This
case needed to be extended to "!=".

+3 tests passing.