### PR TITLE
typing: check fields access control

### DIFF
--- a/src/orangejoos/ast_printer.cr
+++ b/src/orangejoos/ast_printer.cr
@@ -214,7 +214,11 @@ module AST
       end
       print_child "Modifiers: #{node.modifiers.join(", ")}"
       last_child = node.params.empty? && (!node.body? || node.body.empty?)
-      print_child("Returns: #{node.typ.to_s}", last_child)
+      if node.typ?
+        print_child("Returns: #{node.typ.to_s}", last_child)
+      else
+        print_child("Returns: void", last_child) if node.typ?
+      end
       last_child = !node.body? || node.body.empty?
       print_child("Params: #{(node.params.map { |i| i.to_s }).join(", ")}", last_child) if !node.params.empty?
       if node.body? && !node.body.empty?


### PR DESCRIPTION
Previously, if a field was used the access control rules were never
checked. Now, if a field is declared as protected[0], then we check if
the access is allowed[1].

[0]: Remember, we only have public and protected.

[1]: Protected field access is defined as: the class containing the
field or any item in the same package is allowed to access it.

+7 passing tests for A3.