### PR TITLE
typing: check array index or init expressions

### DIFF
--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -958,6 +958,10 @@ module AST
     end
 
     def resolve_type(namespace : ImportNamespace) : Typing::Type
+      if !index.resolve_type(namespace).is_number?
+        raise TypeCheckStageError.new("array index expression is not a number: expr=#{index.to_s}")
+      end
+
       expr.get_type(namespace).from_array_type
     end
 
@@ -990,6 +994,10 @@ module AST
     end
 
     def resolve_type(namespace : ImportNamespace) : Typing::Type
+      if !dim.resolve_type(namespace).is_number?
+        raise TypeCheckStageError.new("array init dimension expression is not a number: expr=#{dim.to_s}")
+      end
+
       # Crystal cannot modify the type from a method, `#arr`.
       node = arr
       case node

--- a/src/orangejoos/typing.cr
+++ b/src/orangejoos/typing.cr
@@ -107,6 +107,10 @@ module Typing
       return typ == Types::STATIC
     end
 
+    def is_number? : Bool
+      return NUMBERS.includes?(typ)
+    end
+
     def ==(other : Type) : Bool
       # When both are not arrays, instatly false.
       return false unless other.is_array == self.is_array


### PR DESCRIPTION
Previously, we did not check the type on `arr[int]` or `new Type[int]`
expressions.

+2 tests