### PR TITLE
typing: fix protected field cases

### DIFF
--- a/src/orangejoos/ast_printer.cr
+++ b/src/orangejoos/ast_printer.cr
@@ -217,7 +217,7 @@ module AST
       if node.typ?
         print_child("Returns: #{node.typ.to_s}", last_child)
       else
-        print_child("Returns: void", last_child) if node.typ?
+        print_child("Returns: void", last_child)
       end
       last_child = !node.body? || node.body.empty?
       print_child("Params: #{(node.params.map { |i| i.to_s }).join(", ")}", last_child) if !node.params.empty?

--- a/src/orangejoos/simplification.cr
+++ b/src/orangejoos/simplification.cr
@@ -746,7 +746,9 @@ class Simplification
         member_decls = simplify_tree(body_tree).as(Array(AST::MemberDecl))
       end
 
+
       class_decl = AST::ClassDecl.new(name.val, modifiers, super_class, interfaces, member_decls)
+      member_decls.each {|m| m.parent = class_decl}
       return class_decl
     when "InterfaceDeclaration"
       name = simplify(tree.tokens.get_tree!("Identifier")).as(AST::Identifier)
@@ -770,6 +772,7 @@ class Simplification
       end
 
       iface_decl = AST::InterfaceDecl.new(name.val, modifiers, extensions, member_decls)
+      member_decls.each {|m| m.parent = iface_decl}
       return iface_decl
     else
       raise UnexpectedNodeException.new("unexepected node name=#{tree.name}")


### PR DESCRIPTION
Checking if protected access is allowed is slightly more complicated
than expected. Consider the following cases, where all classes are in
separate packages:

    class A
      protected field foo;

    class B extends A

    class C extends B
      foo(D d) { return d.foo; }
      foo(E e) { return e.foo; }
      foo(F f) { return f.foo; }

    class D extends C

    class E extends B

    class F extends C
      protected field foo;

In this example, `foo(D d)` is allowed, even though C is not in the same
package as A. This is because C is a sub-class of D. On the other
hand, `foo(E e)` generates a compile time error because even though the
field is declared in a class that is in the sub-class to C because E is
not a sub-class of C. `foo(F f)` also fails because the field being
referenced is not in a sub-class of `C`.

+1 test