### PR TITLE
typecheck: prevent Object assigning to non-Object types

### DIFF
--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -819,11 +819,15 @@ module AST
           # Special case: char can be added with numeric types, but
           # cannot be assigned between numeric types.
           if lhs.typ == Typing::Types::CHAR && rhs.typ != Typing::Types::CHAR
-            raise TypeCheckStageError.new("assignment failure between LHS=#{operands[0].get_type(namespace).to_s} RHS#{operands[1].get_type(namespace).to_s}")
+            raise TypeCheckStageError.new("assignment failure between LHS=#{operands[0].get_type(namespace).to_s} RHS=#{operands[1].get_type(namespace).to_s}")
+          end
+          # Special case: you cannot assign Object to things.
+          if rhs.typ == Typing::Types::INSTANCE && rhs.ref.qualified_name == "java.lang.Object" && lhs.typ == Typing::Types::INSTANCE && lhs.ref.qualified_name != "java.lang.Object"
+            raise TypeCheckStageError.new("assignment failure between LHS=#{operands[0].get_type(namespace).to_s} RHS=#{operands[1].get_type(namespace).to_s} (cannot assign Object to other things)")
           end
           return lhs
         else
-          raise TypeCheckStageError.new("assignment failure between LHS=#{operands[0].get_type(namespace).to_s} RHS#{operands[1].get_type(namespace).to_s}")
+          raise TypeCheckStageError.new("assignment failure between LHS=#{operands[0].get_type(namespace).to_s} RHS=#{operands[1].get_type(namespace).to_s}")
         end
       end
 

--- a/src/orangejoos/typing.cr
+++ b/src/orangejoos/typing.cr
@@ -226,7 +226,11 @@ class StmtTypeCheckVisitor < Visitor::GenericVisitor
     # Special case: char can be added with numeric types, but
     # cannot be assigned between numeric types.
     if init_typ.typ == Typing::Types::CHAR && typ.typ != Typing::Types::CHAR
-      raise TypeCheckStageError.new("assignment failure between LHS=#{typ.typ.to_s} RHS=#{init_typ.typ.to_s}")
+      raise TypeCheckStageError.new("assignment failure between LHS=#{typ.to_s} RHS=#{init_typ.to_s}")
+    end
+    # Special case: you cannot assign Object to things.
+    if init_typ.typ == Typing::Types::INSTANCE && init_typ.ref.qualified_name == "java.lang.Object" && typ.typ == Typing::Types::INSTANCE && typ.ref.qualified_name != "java.lang.Object"
+      raise TypeCheckStageError.new("assignment failure between LHS=#{typ.to_s} RHS=#{init_typ.to_s}")
     end
     super
   end
@@ -243,6 +247,10 @@ class StmtTypeCheckVisitor < Visitor::GenericVisitor
       # Special case: char can be added with numeric types, but
       # cannot be assigned between numeric types.
       if method_typ.typ == Typing::Types::CHAR && return_typ.typ != Typing::Types::CHAR
+        raise TypeCheckStageError.new("cannot return here #{method_typ.to_s} RHS=#{return_typ.to_s}")
+      end
+      # Special case: you cannot assign Object to things.
+      if return_typ.typ == Typing::Types::INSTANCE && return_typ.ref.qualified_name == "java.lang.Object" && method_typ.typ == Typing::Types::INSTANCE && method_typ.ref.qualified_name != "java.lang.Object"
         raise TypeCheckStageError.new("cannot return here #{method_typ.to_s} RHS=#{return_typ.to_s}")
       end
     end


### PR DESCRIPTION
Previously, the statements would be allowed to go through:

    Object o = null;
    String s = o;
    String s = (o = "hi");

Whereas, the later 2 lines are not allowed because Object types cannot
be implicitly assigned to other types. This is an error. It must be
instead cast.

+1 test.