### PR TITLE
nameres: do not resolve this-fields in static methods

### DIFF
--- a/src/orangejoos/name_resolution.cr
+++ b/src/orangejoos/name_resolution.cr
@@ -635,7 +635,7 @@ class MethodEnvironmentVisitor < Visitor::GenericVisitor
     @current_method_name = node.name
     # Set up the field namespace.
     if node.has_mod?("static")
-      @field_namespace = @type_decl_static_fields[type_decl_node.name]
+      @field_namespace = [] of NamedTuple(name: String, decl: DeclWrapper)
     else
       @field_namespace = @type_decl_instance_fields[type_decl_node.name]
     end


### PR DESCRIPTION
Previously, within static methods we would resolve static fields with
implicit-this. As it is a static method, there is no implicit-this. For
example:

    public class A {
      public static int x = 1;
      public static int foo() {
        return x;
      }
    }

The `x` call is not allowed as it is implicitly referencing `A` there.
Instead, it must be used as `A.x`.

+1 test (in typing, not sure if this would impact A2 tests)