### PR TITLE
typing: check classes for default constructors

### DIFF
--- a/pub/assignment_testcases/a3/Je_6_ConstructorPresent_Super_NoDefault/Foo.java
+++ b/pub/assignment_testcases/a3/Je_6_ConstructorPresent_Super_NoDefault/Foo.java
@@ -1,5 +1,5 @@
 public class Foo {
 
-    public Foo(String s) {}
+    public Foo(int s) {}
 
 }

--- a/src/orangejoos/ast.cr
+++ b/src/orangejoos/ast.cr
@@ -45,6 +45,10 @@ module AST
     def initialize(@name : String, @params : Array(Typing::Type))
     end
 
+    def self.constructor(params : Array(Typing::Type)) : MethodSignature
+      return MethodSignature.new("<CONSTRUCTOR>", params)
+    end
+
     def initialize(method : MethodDecl)
       @name = method.name
       @params = method.params.map { |p| p.typ.to_type }
@@ -64,6 +68,10 @@ module AST
 
     def params_equiv(other : MethodSignature)
       params.size == other.params.size && params.zip(other.params).all? { |a, b| a.equiv(b) }
+    end
+
+    def to_s
+      return "(MethodSignature {#{name}} params=[#{params.map &.to_s}])"
     end
   end
 
@@ -379,6 +387,8 @@ module AST
     getter interfaces : Array(Name) = [] of Name
     getter body : Array(MemberDecl) = [] of MemberDecl
 
+    property is_inherited : Bool = false
+
     def initialize(@name : String, modifiers : Array(Modifier), @super_class : Name?, @interfaces : Array(Name), @body : Array(MemberDecl))
       self.modifiers = modifiers
     end
@@ -442,7 +452,7 @@ module AST
     end
 
     def constructor?(args : Array(Typing::Type)) : ConstructorDecl?
-      searching_sig = MethodSignature.new("<CONSTRUCTOR>", args)
+      searching_sig = MethodSignature.constructor(args)
       result = constructors.find { |c| c.signature.equiv(searching_sig) }
       return result
     end
@@ -1455,7 +1465,7 @@ module AST
     end
 
     def signature : MethodSignature
-      return MethodSignature.new("<CONSTRUCTOR>", params.map(&.typ.to_type))
+      return MethodSignature.constructor(params.map(&.typ.to_type))
     end
 
     def ast_children : Array(Node)

--- a/src/orangejoos/name_resolution.cr
+++ b/src/orangejoos/name_resolution.cr
@@ -447,6 +447,7 @@ class CycleVisitor < Visitor::GenericVisitor
   def visit(node : AST::ClassDecl) : Nil
     if node.super_class?
       soup_class = node.super_class.ref.as(AST::ClassDecl)
+      soup_class.is_inherited = true
       @cycle_tracker.add_edge(node.qualified_name, soup_class.qualified_name)
     end
 


### PR DESCRIPTION
Classes are required to have a default constructor if it is a
super-class, as the sub-class automatically calls the default
constructor at the beginning of its constructors.

+1 test