### PR TITLE
parser: add parse tree flattening step

### DIFF
--- a/spec/parse_simplification_spec.cr
+++ b/spec/parse_simplification_spec.cr
@@ -1,0 +1,37 @@
+require "./spec_helper"
+require "../src/orangejoos/parser"
+require "../src/orangejoos/parse_tree"
+
+describe ParseSimplification do
+  describe "#flatten" do
+    it "flattens expression trees" do
+      # Test case tree:
+      #    AndExpression
+      #      EqualityExpression
+      #        RelationalExpression
+      #          AdditiveExpression
+      #            1
+      #            +
+      #            3
+      tree = ParseTree.new("AndExpression", [
+        ParseTree.new("EqualityExpression", [
+          ParseTree.new("RelationalExpression", [
+            ParseTree.new("AdditiveExpression", [
+              Lexeme.new(Type::NumberLiteral, 1, "1").as(ParseNode),
+              Lexeme.new(Type::Operator, 1, Operator::SUB).as(ParseNode),
+              Lexeme.new(Type::NumberLiteral, 1, "3").as(ParseNode),
+            ]).as(ParseNode)
+          ]).as(ParseNode)
+        ]).as(ParseNode)
+      ])
+
+      # Attempt to flatten the tree.
+      result = ParseSimplification.flatten_tree(tree)
+      result.name.should eq "AdditiveExpression"
+      result.tokens.size.should eq 3
+      result.tokens.to_a[0].as(Lexeme).sem.should eq "1"
+      result.tokens.to_a[1].as(Lexeme).sem.should eq "-"
+      result.tokens.to_a[2].as(Lexeme).sem.should eq "3"
+    end
+  end
+end

--- a/src/orangejoos/parse_tree.cr
+++ b/src/orangejoos/parse_tree.cr
@@ -60,7 +60,7 @@ end
 # A ParseTree is a parse node that represents a non-terminal rule.
 # It consists of a list of *tokens* that are the RHS of the rule.
 class ParseTree < ParseNode
-  getter tokens : ParseNodes
+  property tokens : ParseNodes
   getter name : String
 
   def initialize(@name : String, tokens : Array(ParseNode))

--- a/src/orangejoos/pipeline.cr
+++ b/src/orangejoos/pipeline.cr
@@ -156,6 +156,8 @@ class Pipeline
     # Load LALR(1) prediction table and parse tokens of each source file.     #
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - #
     @sources.each { |file| do_parse!(@table, file) }
+    # Flatten the parse trees.
+    @sources.each { |f| f.parse_tree = ParseSimplification.flatten_tree(f.parse_tree) }
     @sources.map &.debug_print(Stage::PARSE) if @verbose
     return true if @end_stage == Stage::PARSE
 


### PR DESCRIPTION
This will reduce the depth of the parse tree for expressions. Due to how
the grammar is designed for handling expression precedence, parsing
expressions caused an large tree depth. An iterative based solution was
added to traverse through the tree and flatten it.

Ideally, the entire simplification process will be translated to an
iterative solution similar to the flattening step in order to prevent
recursive depth issues (due to toom any function calls).