### PR TITLE
codegen: handle castexpr asm for numeric casts

### DIFF
--- a/lib/asm/file_dsl.cr
+++ b/lib/asm/file_dsl.cr
@@ -119,7 +119,7 @@ module ASM
       self.instr i
     end
 
-    def asm_basic_math(op : String, r1 : Register, imm : Int32) : Nil
+    def asm_basic_math(op : String, r1 : Register, imm : Int32 | String) : Nil
       i = Instruction.new("#{op}", "#{r1}, #{imm.to_s}")
       i.write_registers.add(r1)
       i.read_registers.add(r1)
@@ -133,6 +133,10 @@ module ASM
 
     def asm_sub(r1 : Register, r2 : Register | Int32) : Nil
       asm_basic_math("SUB", r1, r2)
+    end
+
+    def asm_and(r1 : Register, r2 : Register | Int32 | String) : Nil
+      asm_basic_math("AND", r1, r2)
     end
 
     def asm_imul(r1 : Register, r2 : Register) : Nil

--- a/pub/assignment_testcases/a5/J1_CE_cast_truncation.java
+++ b/pub/assignment_testcases/a5/J1_CE_cast_truncation.java
@@ -1,0 +1,7 @@
+public class J1_CE_cast_truncation {
+    public J1_CE_cast_truncation() {}
+    public static int test() {
+        if (1 == ((int) ((byte) 257))) return 1;
+        return 0;
+    }
+}


### PR DESCRIPTION
When casting between numeric types, there need to be two things
considered when casting:
1) When upcasting (smaller to larger numeric), the remainder of the
   register needs to be zero'd. This may not need be needed if all math
   ops stay in 32-bit ops, but is a safety guard.
2) When downcasting, the remaining bits need to be zero'd (truncated).

Aside: we need to handle implicit casting for assignment to truncate
bits. This is because math ops upcast to integers, but then if we assign
to a char we need to be sure to truncate.