### PR TITLE
lib: fix ordered_hash re-inserts and add testing

### DIFF
--- a/lib/ordered_hash.cr
+++ b/lib/ordered_hash.cr
@@ -2,14 +2,19 @@ class OrderedHash(K, V)
   def initialize
     @arr = [] of K
     @dict = Hash(K, V).new
+    @index_dict = Hash(K, Int32).new
   end
 
   def push(k : K, v : V)
+    # Delete the previous value from the ordering if it is overwritten.
+    @arr.delete_at(@index_dict[k]) if @dict.has_key?(k)
     @arr.push(k)
     @dict[k] = v
+    @index_dict[k] = @arr.size - 1
     return
   end
 
+  # Pops the oldest item in the `OrderedHash`.
   def pop : V
     k = @arr.shift # a queue, use `.pop` for a stack
     v = @dict[k]
@@ -18,7 +23,11 @@ class OrderedHash(K, V)
   end
 
   def [](k : K) : V
-    return self.fetch(k)
+    return @dict[k]
+  end
+
+  def []?(k : K) : V?
+    return @dict[k]?
   end
 
   def fetch(k : K, default) : V
@@ -29,7 +38,18 @@ class OrderedHash(K, V)
     return @dict.fetch(k)
   end
 
-  def includes?(k : K) : Bool
-    return @dict.includes?(k)
+  def has_key?(k : K) : Bool
+    return @dict.has_key?(k)
+  end
+
+  # Iterates through the dictionary in order.
+  def each(&block : (K, V) -> _)
+    @arr.each do |k|
+      yield(k, @dict[k])
+    end
+  end
+
+  def size : Int32
+    @dict.size
   end
 end

--- a/spec/ordered_hash_spec.cr
+++ b/spec/ordered_hash_spec.cr
@@ -1,0 +1,37 @@
+require "./spec_helper"
+require "ordered_hash"
+
+describe OrderedHash do
+  it "does not duplicate same-keys in the ordering" do
+    h = OrderedHash(Int32, Int32).new
+    h.push(1, 2)
+    h.push(1, 3)
+    h.size.should eq 1
+    h[1]?.should eq 3
+
+    values = [] of Tuple(Int32, Int32)
+    h.each { |k, v| values.push(Tuple.new(k, v)) }
+    values.size.should eq 1
+    values[0].should eq Tuple.new(1, 3)
+  end
+
+  it "correctly has ordering" do
+    h = OrderedHash(Int32, Int32).new
+    h.push(1, 2)
+    h.push(2, 10)
+    h.push(0, 20)
+    h.size.should eq 3
+
+    # Fetch the ordered list from the OrderedHash.
+    values = [] of Tuple(Int32, Int32)
+    h.each { |k, v| values.push(Tuple.new(k, v)) }
+
+    expected_values = [
+      Tuple(Int32, Int32).new(1, 2),
+      Tuple(Int32, Int32).new(2, 10),
+      Tuple(Int32, Int32).new(0, 20),
+    ] of Tuple(Int32, Int32)
+
+    values.should eq expected_values
+  end
+end


### PR DESCRIPTION
Even though the changes aren't used by anything, this was from intermediary work for multiple localvars so I thought it might be useful to keep around.

---

Previously, if a value was re-inserted into OrderedHash it would
duplicate the value in the ordering list. In addition to fixing that,
there is now an exposed way to iterate through the ordering.

Tests are also added to test this functionality correctly.