### PR TITLE
codegen: raise an error for unimplemented or unexpected nodes

### DIFF
--- a/src/orangejoos/visitor.cr
+++ b/src/orangejoos/visitor.cr
@@ -5,7 +5,7 @@ module Visitor
   abstract class Visitor
     @depth = 0
 
-    abstract def visit(node : AST::PrimativeTyp) : Nil
+    abstract def visit(node : AST::PrimitiveTyp) : Nil
     abstract def visit(node : AST::ClassTyp) : Nil
     abstract def visit(node : AST::Identifier) : Nil
     abstract def visit(node : AST::PackageDecl) : Nil


### PR DESCRIPTION
This is an attempt to be loud about unimplemented features and cases.