### PR TITLE
add object init and field handling

### DIFF
--- a/c
+++ b/c
@@ -18,6 +18,7 @@ if [ $ASSN == "5" ]; then
       output_file="${file%.s}.o"
       nasm -O1 -f macho -F dwarf -g $file -o $output_file
     done
+    nasm -O1 -f macho -F dwarf -g pub/stdlib/5.0/runtime.s -o output/__runtime.o
     ld -o output/main output/*.o
     ./output/main
     echo $?
@@ -27,6 +28,7 @@ if [ $ASSN == "5" ]; then
       output_file="${file%.s}.o"
       nasm -O1 -f elf -g -F dwarf $file -o $output_file
     done
+    nasm -O1 -f elf -g -F dwarf pub/stdlib/5.0/runtime.s -o output/__runtime.o
     ld  -melf_i386 -o output/main output/*.o
     ./output/main
     echo $?

--- a/lib/asm/label.cr
+++ b/lib/asm/label.cr
@@ -1,4 +1,7 @@
 class ASM::Label
+
+  MALLOC = Label.new("__malloc")
+
   property val : String
 
   def initialize(@val : String)
@@ -13,7 +16,11 @@ class ASM::Label
   end
 
   def self.from_ctor(path : String, class_name : String, types : Array(String)) : Label
-    return Label.new("method$#{path}$#{class_name}$#__CTOR##{types.join("#")}")
+    return Label.new("ctor$#{path}$#{class_name}##{types.join("#")}")
+  end
+
+  def self.from_class_for_init(path : String, class_name : String) : Label
+    return Label.new("internal$#{path}$#{class_name}$#__INIT")
   end
 
   def self.from_field(path : String, class_name : String, field : String) : Label

--- a/pub/assignment_testcases/a5/J1_CE_object_init_field.java
+++ b/pub/assignment_testcases/a5/J1_CE_object_init_field.java
@@ -1,0 +1,16 @@
+// PARSER_WEEDER,CODE_GENERATION
+public class J1_CE_object_init_field {
+
+    public int x = 1337;
+    public int y = 1;
+
+    public J1_CE_object_init_field(){
+        x = 2;
+        y = 123;
+    }
+
+    public static int test() {
+        J1_CE_object_init_field a = new J1_CE_object_init_field();
+        return a.y;
+    }
+}

--- a/src/orangejoos/codegen/class_instance.cr
+++ b/src/orangejoos/codegen/class_instance.cr
@@ -1,0 +1,40 @@
+# The size of the base class, prior to the fields in the layout.
+# TODO: (joey) As we currently do not have the vptr or type in the
+# layout, this is 0.
+BASE_SIZE = 0
+VPTR_OFFSET = 0
+TYP_OFFSET = 0
+
+
+# `ClassInstance` is used for generating code involving a class
+# instances, including field addressing and method invocation.
+class ClassInstance
+  property size : Int32 = 0
+
+  # field name => (offset, decl)
+  property fields = OrderedHash(String, Tuple(Int32, AST::FieldDecl)).new
+
+  getter init_label : ASM::Label
+
+  def initialize(cls : AST::ClassDecl)
+    @init_label = ASM::Label.from_class_for_init(cls.package, cls.name)
+
+    current_offset = 0
+    # TODO: (joey) the offsets should account for super fields.
+    cls.fields.each do |field|
+      self.fields.push(field.name, Tuple.new(current_offset, field))
+      # NOTE: currently, every data-type is only a double-word.
+      current_offset += 4
+    end
+
+    self.size = BASE_SIZE + current_offset
+  end
+
+  def field_as_address(field : AST::FieldDecl)
+    return Register::ESI.as_address_offset(BASE_SIZE + field_offset(field))
+  end
+
+  def field_offset(field : AST::FieldDecl)
+    return fields[field.name][0]
+  end
+end

--- a/src/orangejoos/visitor.cr
+++ b/src/orangejoos/visitor.cr
@@ -43,6 +43,7 @@ module Visitor
     abstract def visit(node : AST::CastExpr) : Nil
     abstract def visit(node : AST::ParenExpr) : Nil
     abstract def visit(node : AST::Variable) : Nil
+    abstract def visit(node : AST::ExprFieldAccess) : Nil
 
     def descend
       @depth += 1


### PR DESCRIPTION
To support these features, the following has been added:
- Class instance layouts
- Constructor bodies
- Constructor calling
- Instance field initialization
- Field addressing
- Field value fetching

In the constructor body, the first action that happens is the space for
the instance layout is allocated with `malloc`. After that, a field
initialization function is called which will execute all of the field
initializers, in order. This is because fields can have arbitrary
expressions within them. After all of this, the remainder of the
constructor is run.

Hereon out, the register `ESI` is dedicated to storing `this` for the
purposes of constructors and instance methods. Hence, any implicit or
explicit reference to `this` is simply accessing the `ESI` register.

Constructor calling is done in the same manner as method invocation,
where a safe call is made that does a backup and restore of the method
context. This now includes the ESI register.

A class, `ClassInstance`, is created for building interfaces codegen
will use involving an instance. In particular, it is tracking the layout
of the object in memory.

Using the `ClassInstance`, addressing and value fetching for fields was
added.