### PR TITLE
add array init, access, assignment, and length

### DIFF
--- a/lib/asm/file_dsl.cr
+++ b/lib/asm/file_dsl.cr
@@ -157,7 +157,7 @@ module ASM
       asm_unary_math("NEG", r1)
     end
 
-    def asm_imul(r1 : Register, r2 : Register) : Nil
+    def asm_imul(r1 : Register, r2 : Register | Int32) : Nil
       asm_binary_math("IMUL", r1, r2)
     end
 
@@ -233,7 +233,7 @@ module ASM
       self.instr i
     end
 
-    def asm_mov(dest : Register | Address, src : Register | Address | Int32) : Nil
+    def asm_mov(dest : Register | Address, src : Register | Address | Int32 | String) : Nil
       i = Instruction.new("MOV", "#{dest.to_s}, #{src.to_s}")
       i.read_registers.add(src) if src.is_a?(Register)
       i.read_registers.add(src.register) if src.is_a?(Address)

--- a/pub/assignment_testcases/a5/J1_CE_array_basic.java
+++ b/pub/assignment_testcases/a5/J1_CE_array_basic.java
@@ -1,0 +1,12 @@
+// PARSER_WEEDER,CODE_GENERATION
+public class J1_CE_array_basic {
+    public J1_CE_array_basic(){}
+
+    public static int test() {
+        int[] a = null;
+        a = new int[4];
+        a[3] = 5;
+        a[2] = 118 + a[3];
+        return a[2]; // Return 123.
+    }
+}

--- a/pub/assignment_testcases/a5/J1_CE_array_length.java
+++ b/pub/assignment_testcases/a5/J1_CE_array_length.java
@@ -1,0 +1,12 @@
+// PARSER_WEEDER,CODE_GENERATION
+public class J1_CE_array_length {
+    public J1_CE_array_length(){}
+
+    public static int test() {
+        int[] a = null;
+        int b = 120;
+        b = b + 3;
+        a = new int[b];
+        return a.length; // Return 123.
+    }
+}


### PR DESCRIPTION
ignore the first commit as it's currently on another PR.

---

Arrays are stored with the length as the first double-word. The data
follows that in the layout. The array pointer itself is shifted so the
data begins at the pointer's address.

Going forward, if we wish to continue storing the array ptr with the
data at the start of the ptr address after vtables are also stored,
we can consistently store the vtable at the [instance_ptr - 4]. That
means that classes too would follow this semantic. This will not impact
the instructions needed for virtual dispatching, as the lookup can have
the -4 offset embedded.